### PR TITLE
KEH-737 Add Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,3 +13,4 @@ A project used to survey out what tools, languages and frameworks are being used
 
 ## Rules
 - Do not use a design system component unless it is an existing component located in the folder i.e. do not invent a new component name
+- Use the design system for building UI unless otherwise specified

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Tech Audit Tool
+Every time you choose to apply a rule(s), explicitly state the rule(s) in the output. You can abbreviate the rule description to a single word or phrase.
+
+## Project Context
+A project used to survey out what tools, languages and frameworks are being used by various projects within DST.
+- Uses the company design system
+
+## Design System Context
+- Written in Nunjucks
+- Offers pre-styled and reusable components
+- Located in `./templates/components`
+- Example implementations of components are located in `./templates/components/<component>/example-<component>.njk`
+
+## Rules
+- Do not use a design system component unless it is an existing component located in the folder i.e. do not invent a new component name

--- a/templates/section_code/hosting.html
+++ b/templates/section_code/hosting.html
@@ -1,7 +1,6 @@
 {% extends "core.html" %}
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/radios/_macro.njk" import onsRadios %}
-{% from "components/accordion/_macro.njk" import onsAccordion %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/label/_macro.njk" import onsLabel %}
 {% block main %}
@@ -18,120 +17,107 @@
     }) }}
     {% endcall %}
     <br>
-        <h1>Hosting</h1>
-        {{ onsAccordion({
-        "id": "accordion-example",
-        "itemsList": [
-            {
-                "title": "More info",
-                "content": "<p>Please specify how your solution is hosted: on-premises (e.g as VMs on servers owned by ONS), in the cloud, or hybrid. If your solution is hosted in the cloud or as a hybrid setup, you will be prompted to enter the cloud service providers used (e.g., AWS, Azure, Google Cloud). </p>"
-            }
-        ]
-    }) }}
-        {{ onsLabel({
+    <h1>Hosting</h1>
+    {{ onsLabel({
         "id": 'hosting-label',
         "for": "hosting",
         "text": 'Where is the solution hosted?',
         "description": 'Select the type of hosting.'
     }) }}
-        {{ onsRadios({
-            "dontWrap": true,
-            "name": "role",
-            "radios": [
-                {
-                    "id": "On-premises",
-                    "label": {
-                        "text": "On-premises"
-                    },
-                    "value": "On-premises"
+    {{ onsRadios({
+        "dontWrap": true,
+        "name": "role",
+        "radios": [
+            {
+                "id": "On-premises",
+                "label": {
+                    "text": "On-premises",
+                    "description": "The solution is hosted on servers owned by ONS"
                 },
-                                {
-                    "id": "Cloud",
-                    "label": {
-                        "text": "Cloud"
-                    },
-                    "value": "Cloud"
+                "value": "On-premises"
+            },
+            {
+                "id": "Cloud",
+                "label": {
+                    "text": "Cloud",
+                    "description": "The solution is hosted on cloud service providers like AWS, Azure, or Google Cloud"
                 },
-                {
-                    "id": "Hybrid",
-                    "label": {
-                        "text": "Hybrid"
-                    },
-                    "value": "Hybrid"
-                }
-                
-            ]
-        }) }}
-        <br>
-            <script src="{{ url_for('static', filename='scripts.js') }}"></script>
-            <form action="{{ url_for('survey') }}" method="GET">
-                {{ onsButton({
-        "id": "save-values-button",
-        "text": "Save and continue",
-        "url": "#",
-        "attributes": {
-            "onclick": "storeHostingData();"
-        }
+                "value": "Cloud"
+            },
+            {
+                "id": "Hybrid",
+                "label": {
+                    "text": "Hybrid",
+                    "description": "The solution is hosted using a combination of on-premises and cloud services"
+                },
+                "value": "Hybrid"
+            }
+        ]
     }) }}
-            </form>
-            <script src="{{ url_for('static', filename='formScripts.js') }}"></script>
-            <script>
-                loadHostingData();
-                document
-                    .getElementById("error-panel")
-                    .style
-                    .display = "none";
-                function storeHostingData() { // Store hosting data in local storage
-                    var hostingType = document.querySelector('input[name="role"]:checked').value;
-                    var name = 'hosting-data';
-                    if (JSON.parse(localStorage.getItem('edit'))) {
-                        name = 'hosting-data-edit';
-                    }
-                    var data = JSON.parse(localStorage.getItem(name)) || {};
-                    data.type = hostingType;
+    <br>
+    <script src="{{ url_for('static', filename='scripts.js') }}"></script>
+    <form action="{{ url_for('survey') }}" method="GET">
+        {{ onsButton({
+            "id": "save-values-button",
+            "text": "Save and continue",
+            "url": "#",
+            "attributes": {
+                "onclick": "storeHostingData();"
+            }
+        }) }}
+    </form>
+    <script src="{{ url_for('static', filename='formScripts.js') }}"></script>
+    <script>
+        loadHostingData();
+        document.getElementById("error-panel").style.display = "none";
+        function storeHostingData() { // Store hosting data in local storage
+            var hostingType = document.querySelector('input[name="role"]:checked').value;
+            var name = 'hosting-data';
+            if (JSON.parse(localStorage.getItem('edit'))) {
+                name = 'hosting-data-edit';
+            }
+            var data = JSON.parse(localStorage.getItem(name)) || {};
+            data.type = hostingType;
 
-                    if (data.type === "On-premises") {
-                        data.others = [];
-                    }
+            if (data.type === "On-premises") {
+                data.others = [];
+            }
 
-                    localStorage.setItem(name, JSON.stringify(data));
+            localStorage.setItem(name, JSON.stringify(data));
 
-                    if (hostingType === "Hybrid" || hostingType === "Cloud") {
-                        window.location.href = "/survey/hosting?stage=2";
-                    } else {
-                        
-                        if (
-                            JSON.parse(localStorage.getItem("hosting-validate")) &&
-                            JSON.parse(localStorage.getItem(name)).type === "On-premises" && 
-                            localStorage.getItem("redirect_url")
-                        ) {
-                            window.location.href = localStorage.getItem("redirect_url");
-                        } else if (
-                            JSON.parse(localStorage.getItem("hosting-validate")) &&
-                            JSON.parse(localStorage.getItem(name)).type === "On-premises"
-                        ){
-                            window.location.href = "/validate_details";
-
-                        }
-                        else {
-                            window.location.href = "{{ url_for('database') }}";
-                        }
-                    }
+            if (hostingType === "Hybrid" || hostingType === "Cloud") {
+                window.location.href = "/survey/hosting?stage=2";
+            } else {
+                if (
+                    JSON.parse(localStorage.getItem("hosting-validate")) &&
+                    JSON.parse(localStorage.getItem(name)).type === "On-premises" && 
+                    localStorage.getItem("redirect_url")
+                ) {
+                    window.location.href = localStorage.getItem("redirect_url");
+                } else if (
+                    JSON.parse(localStorage.getItem("hosting-validate")) &&
+                    JSON.parse(localStorage.getItem(name)).type === "On-premises"
+                ){
+                    window.location.href = "/validate_details";
                 }
-                function loadHostingData() {
-                    var name = 'hosting-data';
-                    if (JSON.parse(localStorage.getItem('edit'))) {
-                        name = 'hosting-data-edit';
-                    }
-                    
-                        var data = JSON.parse(localStorage.getItem(name));
-                        if (data) {
-                            try {
-                                document.getElementById(data.type).checked = true;
-                            } catch {
-                                console.error("Error loading hosting data");
-                            }
-                        }
-                    }
-            </script>
-        {% endblock %}
+                else {
+                    window.location.href = "{{ url_for('database') }}";
+                }
+            }
+        }
+        function loadHostingData() {
+            var name = 'hosting-data';
+            if (JSON.parse(localStorage.getItem('edit'))) {
+                name = 'hosting-data-edit';
+            }
+            var data = JSON.parse(localStorage.getItem(name));
+            if (data) {
+                try {
+                    document.getElementById(data.type).checked = true;
+                } catch {
+                    console.error("Error loading hosting data");
+                }
+            }
+        }
+    </script>
+{% endblock %}

--- a/templates/section_code/hosting.html
+++ b/templates/section_code/hosting.html
@@ -3,6 +3,7 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/label/_macro.njk" import onsLabel %}
+{% from "components/accordion/_macro.njk" import onsAccordion %}
 {% block main %}
 <style>
 
@@ -28,6 +29,15 @@
     {% endcall %}
     <br>
     <h1>Hosting</h1>
+    {{ onsAccordion({
+        "id": "accordion-example",
+        "itemsList": [
+            {
+                "title": "More info",
+                "content": "<p>Please specify how your solution is hosted: on-premises (e.g as VMs on servers owned by ONS), in the cloud, or hybrid. If your solution is hosted in the cloud or as a hybrid setup, you will be prompted to enter the cloud service providers used (e.g., AWS, Azure, Google Cloud). </p>"
+            }
+        ]
+    }) }}
     {{ onsLabel({
         "id": 'hosting-label',
         "for": "hosting",
@@ -42,7 +52,7 @@
                 "id": "On-premises",
                 "label": {
                     "text": "On-premises",
-                    "description": "The solution is hosted on servers owned by ONS"
+                    "description": "Hosted on servers owned by ONS"
                 },
                 "value": "On-premises"
             },
@@ -50,7 +60,7 @@
                 "id": "Cloud",
                 "label": {
                     "text": "Cloud",
-                    "description": "The solution is hosted on cloud service providers like AWS, Azure, or Google Cloud"
+                    "description": "Hosted on cloud service providers like AWS, Azure, or Google Cloud"
                 },
                 "value": "Cloud"
             },
@@ -58,7 +68,7 @@
                 "id": "Hybrid",
                 "label": {
                     "text": "Hybrid",
-                    "description": "The solution is hosted using a combination of on-premises and cloud services"
+                    "description": "Hosted using a combination of on-premises and cloud services"
                 },
                 "value": "Hybrid"
             }

--- a/templates/section_code/hosting.html
+++ b/templates/section_code/hosting.html
@@ -4,6 +4,16 @@
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/label/_macro.njk" import onsLabel %}
 {% block main %}
+<style>
+
+    .ons-radios__items {
+        width: fit-content !important;
+    }
+    .ons-radios__item {
+        width: 100% !important;
+    }
+
+</style>
     {% call onsPanel({
         "id": "error-panel",
         "title": 'Error',

--- a/templates/section_project/developed.html
+++ b/templates/section_project/developed.html
@@ -3,8 +3,18 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/question/_macro.njk" import onsQuestion %}
 {% from "components/label/_macro.njk" import onsLabel %}
+{% from "components/accordion/_macro.njk" import onsAccordion %}
 {% block main %}
     <h1>Developed</h1>
+    {{ onsAccordion({
+        "id": "accordion-example",
+        "itemsList": [
+            {
+                "title": "More info",
+                "content": "<p>Enter details about whether the project was developed in-house, outsourced or in partnership with another company.</p>"
+            }
+        ]
+    }) }}
     <form action="{{ url_for('survey') }}" method="GET">
         {{ onsLabel({
             "id": 'developed-label',
@@ -24,7 +34,7 @@
                     "id": "in-house",
                     "label": {
                         "text": "In House",
-                        "description": "The software was developed internally by your own team"
+                        "description": "Developed internally by your own team"
                     },
                     "value": "In House"
                 },
@@ -32,7 +42,7 @@
                     "id": "outsourced",
                     "label": {
                         "text": "Outsourced",
-                        "description": "The software was developed by an external company"
+                        "description": "Developed by an external company"
                     },
                     "value": "Outsourced",
                     "other": {
@@ -47,7 +57,7 @@
                     "id": "partnership",
                     "label": {
                         "text": "Partnership",
-                        "description": "The software was developed in collaboration with another company"
+                        "description": "Developed in collaboration with another company"
                     },
                     "value": "Partnership",
                     "other": {

--- a/templates/section_project/developed.html
+++ b/templates/section_project/developed.html
@@ -2,30 +2,20 @@
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/question/_macro.njk" import onsQuestion %}
-{% from "components/accordion/_macro.njk" import onsAccordion %}
 {% from "components/label/_macro.njk" import onsLabel %}
 {% block main %}
     <h1>Developed</h1>
-    {{ onsAccordion({
-        "id": "accordion-example",
-        "itemsList": [
-            {
-                "title": "More info",
-                "content": "<p>Enter details about whether the project was developed in-house, outsourced or in partnership with another company.</p>"
-            }
-        ]
-    }) }}
     <form action="{{ url_for('survey') }}" method="GET">
         {{ onsLabel({
-    "id": 'developed-label',
-    "for": "developed",
-    "text": 'Where was this Software Developed?',
-    "description": 'Select the option that best describes how the project was developed.'
-}) }}
+            "id": 'developed-label',
+            "for": "developed",
+            "text": 'Where was this Software Developed?',
+            "description": 'Select the option that best describes how the project was developed.'
+        }) }}
         {% call onsQuestion({
-        "classes": "ons-u-mt-no",
-        "legendIsQuestionTitle": true
-    }) %}
+            "classes": "ons-u-mt-no",
+            "legendIsQuestionTitle": true
+        }) %}
         {{ onsRadios({
             "dontWrap": true,
             "name": "developed",
@@ -33,16 +23,17 @@
                 {
                     "id": "in-house",
                     "label": {
-                        "text": "In House"
+                        "text": "In House",
+                        "description": "The software was developed internally by your own team"
                     },
                     "value": "In House"
                 },
                 {
                     "id": "outsourced",
                     "label": {
-                        "text": "Outsourced"
+                        "text": "Outsourced",
+                        "description": "The software was developed by an external company"
                     },
-                    "value": "outsourced",
                     "value": "Outsourced",
                     "other": {
                         "id": "other-input-1",
@@ -55,7 +46,8 @@
                 {
                     "id": "partnership",
                     "label": {
-                        "text": "Partnership"
+                        "text": "Partnership",
+                        "description": "The software was developed in collaboration with another company"
                     },
                     "value": "Partnership",
                     "other": {
@@ -71,13 +63,13 @@
         {% endcall %}
         <script src="{{ url_for('static', filename='formScripts.js') }}"></script>
         {{ onsButton({
-        "id": "save-values-button",
-        "url": url_for('stage'),
-        "text": "Save and continue",
-        "attributes": {
-            "onclick": "storeData();"
-        }
-    }) }}
+            "id": "save-values-button",
+            "url": url_for('stage'),
+            "text": "Save and continue",
+            "attributes": {
+                "onclick": "storeData();"
+            }
+        }) }}
         <script>
             function storeData() { // Store data about where the software was developed in local storage
                 var developed = document.querySelector('input[name="developed"]:checked').value;

--- a/templates/section_project/stage.html
+++ b/templates/section_project/stage.html
@@ -2,37 +2,20 @@
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/radios/_macro.njk" import onsRadios %}
 {% from "components/question/_macro.njk" import onsQuestion %}
-{% from "components/accordion/_macro.njk" import onsAccordion %}
 {% from "components/label/_macro.njk" import onsLabel %}
 {% block main %}
     <h1>Project Stage</h1>
-    {{ onsAccordion({
-        "id": "accordion-example",
-        "itemsList": [
-            {
-                "title": "More info",
-                "content": "<b>Development</b>
-                            <p>The software is being designed, coded, and tested before release.</p>
-
-                            <b>Active Support</b>
-                            <p>The software is released and receives regular updates, bug fixes, and feature enhancements.</p>
-
-                            <b>Unsupported</b>
-                            <p>The software no longer receives updates, fixes, or official assistance.</p>"
-            },
-        ]
-    }) }}
     <form action="{{ url_for('survey') }}" method="GET">
         {{ onsLabel({
-    "id": 'developed-label',
-    "for": "developed",
-    "text": 'What stage is the project at?',
-    "description": 'Select the option that best describes the stage of the project.'
-}) }}
+            "id": 'developed-label',
+            "for": "developed",
+            "text": 'What stage is the project at?',
+            "description": 'Select the option that best describes the stage of the project.'
+        }) }}
         {% call onsQuestion({
-        "classes": "ons-u-mt-no",
-        "legendIsQuestionTitle": true
-    }) %}
+            "classes": "ons-u-mt-no",
+            "legendIsQuestionTitle": true
+        }) %}
         {{ onsRadios({
             "dontWrap": true,
             "name": "stage",
@@ -40,36 +23,39 @@
                 {
                     "id": "Development",
                     "label": {
-                        "text": "Development"
+                        "text": "Development",
+                        "description": "The software is being designed, coded, and tested before release"
                     },
                     "value": "Development"
                 },
                 {
                     "id": "Active Support",
                     "label": {
-                        "text": "Active Support"
+                        "text": "Active Support",
+                        "description": "The software is released and receives regular updates, bug fixes, and feature enhancements"
                     },
-                    "value": "Active Support",
+                    "value": "Active Support"
                 },
                 {
                     "id": "Unsupported",
                     "label": {
-                        "text": "Unsupported"
+                        "text": "Unsupported",
+                        "description": "The software no longer receives updates, fixes, or official assistance"
                     },
-                    "value": "Unsupported",
+                    "value": "Unsupported"
                 }
             ]
         }) }}
         {% endcall %}
         <script src="{{ url_for('static', filename='formScripts.js') }}"></script>
         {{ onsButton({
-        "id": "save-values-button",
-        "url": url_for('project_summary'),
-        "text": "Save and continue",
-        "attributes": {
-            "onclick": "storeData();"
-        }
-    }) }}
+            "id": "save-values-button",
+            "url": url_for('project_summary'),
+            "text": "Save and continue",
+            "attributes": {
+                "onclick": "storeData();"
+            }
+        }) }}
         <script>
             function storeData() {
                 var stage = document.querySelector('input[name="stage"]:checked').value;


### PR DESCRIPTION
This PR introduces instructions for Copilot to work more effectively with the ONS design system.

It also resolves KEH-782 - Set descriptions for radio buttons, by using Copilot with the new instructions as a proof of concept to update pages that are using the design system.

Relevant documentation can be found [here.](https://confluence.ons.gov.uk/display/KEH/Copilot+Guidance)