### PR TITLE
KEH-1204 | Fix Survey Completion Missing

### DIFF
--- a/static/formScripts.js
+++ b/static/formScripts.js
@@ -282,6 +282,7 @@ function changeBtnURL(contactTechData, contactManagerData, projectData, projectD
     
     // Define all validation checks with their URLs and validation functions
     const validations = [
+        // Project Details
         { 
             data: contactTechData, 
             url: '/survey/contact_tech', 
@@ -297,22 +298,25 @@ function changeBtnURL(contactTechData, contactManagerData, projectData, projectD
             url: '/survey/project', 
             validationFn: (data) => validateMultipleFields(data, ['name', 'short_name', 'project_description', 'documentation_link', 'programme_name', 'programme_short_name'])
         },
-        // Developed + Stage missing validation
+        // TODO: Developed + Stage missing validation
         { 
             data: projectDependenciesData, 
             url: '/survey/project_dependencies', 
             validationFn: (data) => Array.isArray(data) && data.length > 0
         },
+        // Code and Architecture
         { 
             data: sourceControlData, 
             url: '/survey/source_control', 
             validationFn: (data) => validateObjectField(data, 'source_control')
         },
+        // TODO: Hosting missing validation
         { 
             data: databaseData, 
             url: '/survey/database', 
             validationFn: (data) => data.others && data.others.length > 0
         },
+        // Technology
         { 
             data: languagesData, 
             url: '/survey/languages', 
@@ -338,6 +342,7 @@ function changeBtnURL(contactTechData, contactManagerData, projectData, projectD
             url: '/survey/publishing', 
             validationFn: (data) => (data.main && data.main.length > 0) || (data.others && data.others.length > 0)
         },
+        // Supporting Tools
         { 
             data: codeEditorsData, 
             url: '/survey/code_editors', 

--- a/static/formScripts.js
+++ b/static/formScripts.js
@@ -258,7 +258,7 @@ function validateMultipleFields(data, fields) {
 
 function changeBtnURL(contactTechData, contactManagerData, projectData, projectDependenciesData, 
     sourceControlData, databaseData, languagesData, 
-    frameworksData, integrationsData, infrastructureData, 
+    frameworksData, integrationsData, infrastructureData, publishingData, 
     codeEditorsData, uiToolsData, diagramToolsData, 
     projectTrackingData, documentationData, communicationData, 
     collaborationData, incidentManagementData, miscellaneousData) {

--- a/static/formScripts.js
+++ b/static/formScripts.js
@@ -31,7 +31,10 @@ function storeContactData(keyBase) {
         role = idRoleMap[selectedId] || selectedId;
     }
 
-    const complete = contactEmail && role;
+    let complete = false;
+    if (contactEmail != '' && role != '') {
+        complete = true;
+    }
 
     const data = {
         contactEmail,
@@ -292,7 +295,7 @@ function changeBtnURL(contactTechData, contactManagerData, projectData, projectD
         { 
             data: projectData, 
             url: '/survey/project', 
-            validationFn: (data) => validateMultipleFields(data, ['project_name', 'project_short_name', 'project_description', 'doc_link'])
+            validationFn: (data) => validateMultipleFields(data, ['name', 'short_name', 'project_description', 'documentation_link'])
         },
         { 
             data: projectDependenciesData, 

--- a/static/formScripts.js
+++ b/static/formScripts.js
@@ -255,7 +255,7 @@ function validateMultipleFields(data, fields) {
     return fields.every(field => {
       const val = data[field];
       // you can also enforce non-empty strings/arrays here:
-      return val !== undefined && val !== null;
+      return val !== undefined && val !== null && val !== '';
     });
   }
 
@@ -295,8 +295,9 @@ function changeBtnURL(contactTechData, contactManagerData, projectData, projectD
         { 
             data: projectData, 
             url: '/survey/project', 
-            validationFn: (data) => validateMultipleFields(data, ['name', 'short_name', 'project_description', 'documentation_link'])
+            validationFn: (data) => validateMultipleFields(data, ['name', 'short_name', 'project_description', 'documentation_link', 'programme_name', 'programme_short_name'])
         },
+        // Developed + Stage missing validation
         { 
             data: projectDependenciesData, 
             url: '/survey/project_dependencies', 

--- a/templates/survey.html
+++ b/templates/survey.html
@@ -152,12 +152,12 @@
             var incidentManagementData = localStorage.getItem('incident_management-data');
             var miscellaneousData = localStorage.getItem('miscellaneous-data');
             
-            changeBtnURL(contactTechData, contactManagerData, projectData, 
+            changeBtnURL(contactTechData, contactManagerData, projectData, projectDependenciesData, 
             sourceControlData, databaseData, languagesData, 
-            frameworksData, integrationsData, infrastructureData, 
+            frameworksData, integrationsData, infrastructureData, publishingData, 
             codeEditorsData, uiDesignData, diagramsData, 
             projectTrackingData, documentationData, communicationData, 
-            collaborationData, incidentManagementData);
+            collaborationData, incidentManagementData, miscellaneousData);
             updateSectionStatus('user-details', [contactTechData, contactManagerData, projectData, developedData, stageData]);
             updateSectionStatus('project-details', [sourceControlData, hostingData, databaseData]);
             updateSectionStatus('developed-details', [frameworksData, infrastructureData, integrationsData, languagesData]);


### PR DESCRIPTION
- publishingData was not defined previously.
- This caused the survey completion to not work.
- This is now fixed.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Before the patch, when getting to the survey summary page, the completions information would not appear.

This was because the function was trying to use a `publishingData` without defining it, causing an error.

This has now been fixed by adding a `publishingData` parameter to the function.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1204 (Jira)

### How to review

- Create new project
- Go through survey
- Double check Survey Summary functionality