### PR TITLE
KEH-1990 Read only access for root files

### DIFF
--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -22,7 +22,8 @@ resource "aws_ecs_task_definition" "ecs_service_definition" {
       name      = "${var.service_subdomain}-task-application"
       image     = "${var.aws_account_id}.dkr.ecr.${var.region}.amazonaws.com/${var.container_image}:${var.container_ver}"
       cpu       = 0,
-      essential = true
+      essential = true,
+      readonlyRootFilesystem = true,
       portMappings = [
         {
           name          = "${var.service_subdomain}-${var.container_port}-tcp",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Made TAT only have read only access to root files to fulfil the trusted advisor alert

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1990

### How to review

Check TAT works properly, check AWS trusted advisor