### PR TITLE
KEH-2058 - Remove Public IP from ECS

### DIFF
--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -122,10 +122,7 @@ resource "aws_ecs_service" "application" {
   network_configuration {
     subnets         = data.terraform_remote_state.ecs_infrastructure.outputs.private_subnets
     security_groups = [aws_security_group.allow_rules_service.id]
-
-    # TODO: The container fails to launch unless a public IP is assigned
-    # For a private ip, you would need to use a NAT Gateway?
-    assign_public_ip = true
+    assign_public_ip = false
   }
 
 }


### PR DESCRIPTION
Removes Public IP Address from ECS to comply with ONS AWS Policy.