### PR TITLE
fix: update IAM key rotation period from 90 to 45 days

### DIFF
--- a/terraform/service/iam.tf
+++ b/terraform/service/iam.tf
@@ -107,5 +107,5 @@ module "iam_key_rotation" {
   iam_username          = aws_iam_user.user.name
   access_key_secret_arn = aws_secretsmanager_secret.access_key.arn
   secret_key_secret_arn = aws_secretsmanager_secret.secret_key.arn
-  rotation_in_days      = 90
+  rotation_in_days      = 45
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

To meet Security Hub control rule:

This control checks whether your IAM users have passwords or active access keys that were not used within the previous 45 days.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x ] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x ] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

Provide links to any related issues.

### How to review

Describe the steps required to test the changes.